### PR TITLE
fixing empty strings

### DIFF
--- a/src/Math/Lexer.php
+++ b/src/Math/Lexer.php
@@ -80,6 +80,8 @@ class Lexer
                 $token = new Token($t, Token::T_LEFT_BRACKET);
             }elseif(')' === $t) {
                 $token = new Token($t, Token::T_RIGHT_BRACKET);
+            }elseif('' === $t) {
+                continue;
             }else {
                 throw new \InvalidArgumentException(sprintf('Syntax error: unknown token "%s"', $t));
             }


### PR DESCRIPTION
in case you put double spaces in your expression, the lexer crashes with an InvalidArgumentException because an empty string is an unknown token. therefor added a continue statement to skip this token:
